### PR TITLE
Use https URLs for openstreetmap.org.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to the Joomla! Framework
 
-Please review [http://framework.joomla.org/contribute](http://framework.joomla.org/contribute) for information on how to contribute to the Framework's development.
+Please review [https://framework.joomla.org/contribute](https://framework.joomla.org/contribute) for information on how to contribute to the Framework's development.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## The OpenStreetMap Package [![Build Status](https://travis-ci.org/joomla-framework/openstreetmap-api.png?branch=master)](https://travis-ci.org/joomla-framework/openstreetmap-api)
 
 ### Using the OpenStreetMap Package
-The intention of the OpenStreetMap package is to provide an easy straightforward interface to work with OpenStreetMap. This is based on version 0.6 of the OpenStreetMap API. You can find more information about the OpenStreetMap API at [http://wiki.openstreetmap.org/wiki/API_v0.6](http://wiki.openstreetmap.org/wiki/API_v0.6).
+The intention of the OpenStreetMap package is to provide an easy straightforward interface to work with OpenStreetMap. This is based on version 0.6 of the OpenStreetMap API. You can find more information about the OpenStreetMap API at [https://wiki.openstreetmap.org/wiki/API_v0.6](https://wiki.openstreetmap.org/wiki/API_v0.6).
 The OpenStreetMap package is built upon the `Joomla\OAuth1` package which provides OAuth 1.0 security infrastructure for the communications. The `Joomla\Http` package is also used as an easy way for the non-secure information exchanges.
 
 ### Initiating the OpenStreetMap class
@@ -38,7 +38,7 @@ $oauth->authenticate();
 $osm = new OpenStreetMap($oauth);
 ```
 
-To obtain a key and secret, you have to obtain an account at OpenStreetMap. Through your account you need to [register](http://www.openstreetmap.org/user/username/oauth_clients/new) your application along with a callback URL.
+To obtain a key and secret, you have to obtain an account at OpenStreetMap. Through your account you need to [register](https://www.openstreetmap.org/user/username/oauth_clients/new) your application along with a callback URL.
 
 ### Accessing OpenStreetMap API
 This API will do all types of interactions with OpenStreetMap API. This has been categorized in to 5 main sections: Changeset, Element, GPS, Info and User. All those inherit from `Joomla\OpenStreetMap\OpenStreetMapObject` and can be initiated through the magic `__get` method of the OpenStreetMap class. Methods contained in each type of object are closely related to the OpenStreetMap API calls.
@@ -89,7 +89,7 @@ print_r($result);
 ```
 
 ### More Information
-Following resources contain more information: [OpenStreetMap API](http://wiki.openstreetmap.org/wiki/API)
+Following resources contain more information: [OpenStreetMap API](https://wiki.openstreetmap.org/wiki/API)
 
 ### Installation via Composer
 Add `"joomla/openstreetmap": "~1.0"` to the require block in your composer.json and then run `composer install`.

--- a/src/OAuth.php
+++ b/src/OAuth.php
@@ -36,19 +36,19 @@ class OAuth extends Client
 		// Setup the access token URL if not already set.
 		if (!isset($options['accessTokenURL']))
 		{
-			$options['accessTokenURL'] = 'http://www.openstreetmap.org/oauth/access_token';
+			$options['accessTokenURL'] = 'https://www.openstreetmap.org/oauth/access_token';
 		}
 
 		// Setup the authorisation URL if not already set.
 		if (!isset($options['authoriseURL']))
 		{
-			$options['authoriseURL'] = 'http://www.openstreetmap.org/oauth/authorize';
+			$options['authoriseURL'] = 'https://www.openstreetmap.org/oauth/authorize';
 		}
 
 		// Setup the request token URL if not already set.
 		if (!isset($options['requestTokenURL']))
 		{
-			$options['requestTokenURL'] = 'http://www.openstreetmap.org/oauth/request_token';
+			$options['requestTokenURL'] = 'https://www.openstreetmap.org/oauth/request_token';
 		}
 
 		// Call the OAuth1\Client constructor to setup the object.

--- a/src/OpenStreetMap.php
+++ b/src/OpenStreetMap.php
@@ -99,7 +99,7 @@ class OpenStreetMap
 		// Setup the default API url if not already set.
 		if (!isset($this->options['api.url']))
 		{
-			$this->options['api.url'] = 'http://api.openstreetmap.org/api/0.6/';
+			$this->options['api.url'] = 'https://api.openstreetmap.org/api/0.6/';
 		}
 	}
 


### PR DESCRIPTION
### Summary of Changes

OpenStreetMap is [moving to https by default](https://github.com/openstreetmap/operations/issues/190) and all oauth calls made to the http endpoint after that [will fail](https://github.com/openstreetmap/openstreetmap-website/pull/1341#issuecomment-258439266). This simple PR converts all openstreetmap.org http calls to https. 

While I was at it, I converted all the other URLs to use https.

No related Joomla or openstreetmap-api issue, no additional tests, no documentation changes.